### PR TITLE
Logo Sizing adjusted

### DIFF
--- a/yr/tutorials/diybookclub.html
+++ b/yr/tutorials/diybookclub.html
@@ -302,7 +302,7 @@
       <p>A lot of us spend all day on our phones, hooked on our favorite apps. We keep typing and swiping, even when we know the risks phones can pose to our attention, privacy, and even our safety.  But the computers in our pockets also create untapped opportunities for young people to learn, connect and transform our communities.</p>
       <p>That’s why MIT and YR Media teamed up to launch the Youth Mobile Power series. YR teens produce stories highlighting how young people use their phones in surprising and powerful ways. Meanwhile, the team at MIT is continually enhancing MIT App Inventor to make it possible for users like you to create apps like the ones featured in YR’s reporting.</p>
       <p>Essentially: get inspired by the story, get busy making your own app!</p>
-      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="100"><img src="../images/logos/MITAppInvlogo1.jpg" width="100"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="100">
+      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="75"><img src="../images/logos/MITAppInvlogo1.jpg" width="75"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="75">
       <p>The YR + MIT collaboration is supported in part by the National Science Foundation. This material is based upon work supported by the National Science Foundation under Grant No. (1614239).   Any opinions, findings and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.</p>
 
       <p>Check out more apps and interactive news content created by YR <a href="https://yr.media/category/interactive/" target="_blank">here</a>. 

--- a/yr/tutorials/dontGetFaked.html
+++ b/yr/tutorials/dontGetFaked.html
@@ -282,7 +282,7 @@
       <p>A lot of us spend all day on our phones, hooked on our favorite apps. We keep typing and swiping, even when we know the risks phones can pose to our attention, privacy, and even our safety.  But the computers in our pockets also create untapped opportunities for young people to learn, connect and transform our communities.</p>
       <p>That’s why MIT and YR Media teamed up to launch the Youth Mobile Power series. YR teens produce stories highlighting how young people use their phones in surprising and powerful ways. Meanwhile, the team at MIT is continually enhancing App Inventor to make it possible for users like you to create apps like the ones featured in YR’s reporting.</p>
       <p>Essentially: get inspired by the story, get busy making your own app!</p>
-      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="100"><img src="../images/logos/MITAppInvlogo1.jpg" width="100"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="100">
+      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="75"><img src="../images/logos/MITAppInvlogo1.jpg" width="75"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="75">
       <p>The YR + MIT collaboration is supported in part by the National Science Foundation. This material is based upon work supported by the National Science Foundation under Grant No. (1614239).   Any opinions, findings and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.</p>
 
       <p>Check out more apps and interactive news content created by YR <a href="https://yr.media/category/interactive/" target="_blank">here</a>. 

--- a/yr/tutorials/hello_bonjour.html
+++ b/yr/tutorials/hello_bonjour.html
@@ -179,7 +179,7 @@
       <p>A lot of us spend all day on our phones, hooked on our favorite apps. We keep typing and swiping, even when we know the risks phones can pose to our attention, privacy, and even our safety.  But the computers in our pockets also create untapped opportunities for young people to learn, connect and transform our communities.</p>
       <p>That’s why MIT and YR Media teamed up to launch the Youth Mobile Power series. YR teens produce stories highlighting how young people use their phones in surprising and powerful ways. Meanwhile, the team at MIT is continually enhancing App Inventor to make it possible for users like you to create apps like the ones featured in YR’s reporting.</p>
       <p>Essentially: get inspired by the story, get busy making your own app!</p>
-      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="100"><img src="../images/logos/MITAppInvlogo1.jpg" width="100"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="100">
+      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="75"><img src="../images/logos/MITAppInvlogo1.jpg" width="75"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="75">
       <p>The YR + MIT collaboration is supported in part by the National Science Foundation. This material is based upon work supported by the National Science Foundation under Grant No. (1614239).   Any opinions, findings and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.</p>
 
       <p>Check out more apps and interactive news content created by YR <a href="https://yr.media/category/interactive/" target="_blank">here</a>. 

--- a/yr/tutorials/mapTheMovement.html
+++ b/yr/tutorials/mapTheMovement.html
@@ -343,7 +343,7 @@
       <p>A lot of us spend all day on our phones, hooked on our favorite apps. We keep typing and swiping, even when we know the risks phones can pose to our attention, privacy, and even our safety.  But the computers in our pockets also create untapped opportunities for young people to learn, connect and transform our communities.</p>
       <p>That’s why MIT and YR Media teamed up to launch the Youth Mobile Power series. YR teens produce stories highlighting how young people use their phones in surprising and powerful ways. Meanwhile, the team at MIT is continually enhancing App Inventor to make it possible for users like you to create apps like the ones featured in YR’s reporting.</p>
       <p>Essentially: get inspired by the story, get busy making your own app!</p>
-      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="100"><img src="../images/logos/MITAppInvlogo1.jpg" width="100"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="100">
+      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="75"><img src="../images/logos/MITAppInvlogo1.jpg" width="75"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="75">
       <p>The YR + MIT collaboration is supported in part by the National Science Foundation. This material is based upon work supported by the National Science Foundation under Grant No. (1614239).   Any opinions, findings and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.</p>
 
       <p>Check out more apps and interactive news content created by YR <a href="https://yr.media/category/interactive/" target="_blank">here</a>. 

--- a/yr/tutorials/moodCounter.html
+++ b/yr/tutorials/moodCounter.html
@@ -178,7 +178,7 @@
       <p>A lot of us spend all day on our phones, hooked on our favorite apps. We keep typing and swiping, even when we know the risks phones can pose to our attention, privacy, and even our safety.  But the computers in our pockets also create untapped opportunities for young people to learn, connect and transform our communities.</p>
       <p>That’s why MIT and YR Media teamed up to launch the Youth Mobile Power series. YR teens produce stories highlighting how young people use their phones in surprising and powerful ways. Meanwhile, the team at MIT is continually enhancing App Inventor to make it possible for users like you to create apps like the ones featured in YR’s reporting.</p>
       <p>Essentially: get inspired by the story, get busy making your own app!</p>
-      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="100"><img src="../images/logos/MITAppInvlogo1.jpg" width="100"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="100">
+      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="75"><img src="../images/logos/MITAppInvlogo1.jpg" width="75"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="75">
       <p>The YR + MIT collaboration is supported in part by the National Science Foundation. This material is based upon work supported by the National Science Foundation under Grant No. (1614239).   Any opinions, findings and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.</p>
 
       <p>Check out more apps and interactive news content created by YR <a href="https://yr.media/category/interactive/" target="_blank">here</a>. 

--- a/yr/tutorials/snapRemix.html
+++ b/yr/tutorials/snapRemix.html
@@ -224,7 +224,7 @@
       <p>A lot of us spend all day on our phones, hooked on our favorite apps. We keep typing and swiping, even when we know the risks phones can pose to our attention, privacy, and even our safety.  But the computers in our pockets also create untapped opportunities for young people to learn, connect and transform our communities.</p>
       <p>That’s why MIT and YR Media teamed up to launch the Youth Mobile Power series. YR teens produce stories highlighting how young people use their phones in surprising and powerful ways. Meanwhile, the team at MIT is continually enhancing App Inventor to make it possible for users like you to create apps like the ones featured in YR’s reporting.</p>
       <p>Essentially: get inspired by the story, get busy making your own app!</p>
-      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="100"><img src="../images/logos/MITAppInvlogo1.jpg" width="100"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="100">
+      <img src="../images/logos/NSF_4-Color_bitmap_Logo.png" width="75"><img src="../images/logos/MITAppInvlogo1.jpg" width="75"><img src="../images/logos/LOGO_YR_PNG_TRANS.png" width="75">
       <p>The YR + MIT collaboration is supported in part by the National Science Foundation. This material is based upon work supported by the National Science Foundation under Grant No. (1614239).   Any opinions, findings and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.</p>
 
       <p>Check out more apps and interactive news content created by YR <a href="https://yr.media/category/interactive/" target="_blank">here</a>. 


### PR DESCRIPTION
The online versions of the  YR tutorials  had logos too big in the the "About Youth  Mobile Power" tab  for some reason, so this edit tries to address this.