### PR TITLE
Dead End Publish your App tab removed

### DIFF
--- a/yr/tutorials/diybookclub.html
+++ b/yr/tutorials/diybookclub.html
@@ -371,7 +371,7 @@
   <h3>Share Your App</h3>
   <div class="setup" id="share_app"></div>
 
-  <h3>Published Apps</h3>
+  <!--<h3>Published Apps</h3>
   <div>
     <div id="container">
      <div class="projectbox"> 
@@ -379,7 +379,7 @@
       <div class="projecttext"><span> Hello World</span> </div>
     </div>
   </div>
-</div>
+</div>-->
 
 <h3>About Youth Mobile Power</h3> 
     <div>

--- a/yr/tutorials/diybookclub.html
+++ b/yr/tutorials/diybookclub.html
@@ -368,8 +368,8 @@
 	
     </div>	
 
-  <h3>Share Your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share Your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
   <!--<h3>Published Apps</h3>
   <div>

--- a/yr/tutorials/dontGetFaked.html
+++ b/yr/tutorials/dontGetFaked.html
@@ -265,8 +265,8 @@
 
   </div>
 
-  <h3>Share your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
   <!--<h3>Published apps</h3>
   <div>

--- a/yr/tutorials/dontGetFaked.html
+++ b/yr/tutorials/dontGetFaked.html
@@ -268,7 +268,7 @@
   <h3>Share your App</h3>
   <div class="setup" id="share_app"></div>
 
-  <h3>Published apps</h3>
+  <!--<h3>Published apps</h3>
   <div>
     <div id="container">
      <div class="projectbox"> 
@@ -276,7 +276,8 @@
       <div class="projecttext"><span> Hello World</span> </div>
     </div>
   </div>
-</div>
+</div>-->
+
 <h3>About Youth Mobile Power</h3> 
     <div>
       <p>A lot of us spend all day on our phones, hooked on our favorite apps. We keep typing and swiping, even when we know the risks phones can pose to our attention, privacy, and even our safety.  But the computers in our pockets also create untapped opportunities for young people to learn, connect and transform our communities.</p>

--- a/yr/tutorials/hello_bonjour.html
+++ b/yr/tutorials/hello_bonjour.html
@@ -168,8 +168,8 @@
       </p>
     </div>
 
-  <h3>Share your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
   <!--<h3>Published apps</h3>
   <div>

--- a/yr/tutorials/hello_bonjour.html
+++ b/yr/tutorials/hello_bonjour.html
@@ -171,7 +171,7 @@
   <h3>Share your App</h3>
   <div class="setup" id="share_app"></div>
 
-  <h3>Published apps</h3>
+  <!--<h3>Published apps</h3>
   <div>
     <div id="container">
      <div class="projectbox"> 
@@ -179,7 +179,7 @@
       <div class="projecttext"><span> Hello World</span> </div>
     </div>
   </div>
-</div>
+</div>-->
 
 <h3>About Youth Mobile Power</h3> 
     <div>

--- a/yr/tutorials/mapTheMovement.html
+++ b/yr/tutorials/mapTheMovement.html
@@ -311,7 +311,7 @@
   <h3>Share your App</h3>
   <div class="setup" id="share_app"></div>
 
-  <h3>Published apps</h3>
+  <!--<h3>Published apps</h3>
   <div>
     <div id="container">
      <div class="projectbox"> 
@@ -319,7 +319,7 @@
       <div class="projecttext"><span> Hello World</span> </div>
     </div>
   </div>
-</div>
+</div>-->
 
 <h3>About Youth Mobile Power</h3> 
     <div>

--- a/yr/tutorials/mapTheMovement.html
+++ b/yr/tutorials/mapTheMovement.html
@@ -308,8 +308,8 @@
 
     </div>	
 
-  <h3>Share your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
   <!--<h3>Published apps</h3>
   <div>

--- a/yr/tutorials/moodCounter.html
+++ b/yr/tutorials/moodCounter.html
@@ -164,7 +164,7 @@
   <h3>Share your App</h3>
   <div class="setup" id="share_app"></div>
 
-  <h3>Published apps</h3>
+  <!--<h3>Published apps</h3>
   <div>
     <div id="container">
      <div class="projectbox"> 
@@ -172,7 +172,8 @@
       <div class="projecttext"><span> Hello World</span> </div>
     </div>
   </div>
-</div>
+</div>-->
+
 <h3>About Youth Mobile Power</h3> 
     <div>
       <p>A lot of us spend all day on our phones, hooked on our favorite apps. We keep typing and swiping, even when we know the risks phones can pose to our attention, privacy, and even our safety.  But the computers in our pockets also create untapped opportunities for young people to learn, connect and transform our communities.</p>

--- a/yr/tutorials/moodCounter.html
+++ b/yr/tutorials/moodCounter.html
@@ -161,8 +161,8 @@
     <p>You can use the <a href="#" onclick="return goToHowToTutorial(5)" title="Tutorial for saving and writing to a file" > file component</a> to store what happens each time the user hits the button.</p> 
   </div>
 
-  <h3>Share your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
   <!--<h3>Published apps</h3>
   <div>

--- a/yr/tutorials/mytodolist.html
+++ b/yr/tutorials/mytodolist.html
@@ -539,8 +539,8 @@
 	
     </div>	
 
-  <h3>Share Your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share Your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
  <!-- <h3>Published Apps</h3>
   <div>

--- a/yr/tutorials/opinion_poll_app.html
+++ b/yr/tutorials/opinion_poll_app.html
@@ -587,8 +587,8 @@
 	
     </div>	
 
-  <h3>Share Your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share Your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
  <!-- <h3>Published Apps</h3>
   <div>

--- a/yr/tutorials/rock-paper-scissors-withAI.html
+++ b/yr/tutorials/rock-paper-scissors-withAI.html
@@ -811,8 +811,8 @@
 	
     </div>	
 
-  <h3>Share Your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share Your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
  <!-- <h3>Published Apps</h3>
   <div>

--- a/yr/tutorials/snapRemix.html
+++ b/yr/tutorials/snapRemix.html
@@ -207,8 +207,8 @@
 
     </div>
 
-  <h3>Share your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
   <!--<h3>Published apps</h3>
   <div>

--- a/yr/tutorials/snapRemix.html
+++ b/yr/tutorials/snapRemix.html
@@ -210,7 +210,7 @@
   <h3>Share your App</h3>
   <div class="setup" id="share_app"></div>
 
-  <h3>Published apps</h3>
+  <!--<h3>Published apps</h3>
   <div>
     <div id="container">
      <div class="projectbox"> 
@@ -218,7 +218,8 @@
       <div class="projecttext"><span> Hello World</span> </div>
     </div>
   </div>
-</div>
+</div>-->
+
 <h3>About Youth Mobile Power</h3> 
     <div>
       <p>A lot of us spend all day on our phones, hooked on our favorite apps. We keep typing and swiping, even when we know the risks phones can pose to our attention, privacy, and even our safety.  But the computers in our pockets also create untapped opportunities for young people to learn, connect and transform our communities.</p>

--- a/yr/tutorials/soundlibrary.html
+++ b/yr/tutorials/soundlibrary.html
@@ -403,8 +403,8 @@
 	
     </div>	
 
-  <h3>Share Your App</h3>
-  <div class="setup" id="share_app"></div>
+  <!--<h3>Share Your App</h3>
+  <div class="setup" id="share_app"></div>-->
 
  <!-- <h3>Published Apps</h3>
   <div>


### PR DESCRIPTION
The Publish your App tab was showing a broken/missing image and a strange interface.
It was already removed from all the 2019 YR tutorials but had forgotten to do so with earlier tutorials.