### PR TITLE
Migrate from Universal Analytics to GA4

### DIFF
--- a/AI/tutorials/ImageClassification.html
+++ b/AI/tutorials/ImageClassification.html
@@ -24,17 +24,14 @@
   } );
 </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/AI/tutorials/PIC1.html
+++ b/AI/tutorials/PIC1.html
@@ -28,17 +28,14 @@
   } );
 </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/AI/tutorials/expression-match.html
+++ b/AI/tutorials/expression-match.html
@@ -28,17 +28,15 @@
   } );
 </script>
 
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
 </head>
 <body>
 

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -80,15 +80,13 @@
           $( ".widget input[type=submit], .widget a, .widget button" ).button();
       } );
     </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
     <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
+      gtag('config', 'G-V6FYGPJVJ4');
     </script>
   </body>
 </html>

--- a/ct/tutorials/hello_its_me.html
+++ b/ct/tutorials/hello_its_me.html
@@ -32,16 +32,14 @@
         } );
   </script>
 
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/ct/tutorials/my_piano.html
+++ b/ct/tutorials/my_piano.html
@@ -32,16 +32,14 @@
         } );
   </script>
 
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/ct/tutorials/two_button_game.html
+++ b/ct/tutorials/two_button_game.html
@@ -32,16 +32,14 @@
         } );
   </script>
 
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/malden/tutorials/ball_bounce.html
+++ b/malden/tutorials/ball_bounce.html
@@ -32,16 +32,14 @@
       } );
   </script>
 
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-      ga('create', 'UA-31803258-2', 'auto');
-      ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/malden/tutorials/dontGetFaked.html
+++ b/malden/tutorials/dontGetFaked.html
@@ -23,23 +23,20 @@
     //$( "button, input, a" ).click( );
   } );
 </script>
-
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
   <script>
         function enlargeVideo(youtubeid) {
            window.parent.postMessage({type:"video", youtubeId: youtubeid}, "*");
       }
   </script>
 
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/malden/tutorials/hello_hola.html
+++ b/malden/tutorials/hello_hola.html
@@ -32,17 +32,14 @@
       } );
   </script>
 
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-      ga('create', 'UA-31803258-2', 'auto');
-      ga('send', 'pageview');
-
-  </script>
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/malden/tutorials/iTunes_API.html
+++ b/malden/tutorials/iTunes_API.html
@@ -31,17 +31,14 @@
           //$( "button, input, a" ).click( );
       } );
   </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-31803258-2', 'auto');
-      ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/malden/tutorials/iot.html
+++ b/malden/tutorials/iot.html
@@ -32,15 +32,13 @@
       } );
     </script>
 
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-ga('create', 'UA-31803258-2', 'auto');
-ga('send', 'pageview');
-
+      gtag('config', 'G-V6FYGPJVJ4');
     </script>
   </head>
   <body>

--- a/malden/tutorials/talk_to_me.html
+++ b/malden/tutorials/talk_to_me.html
@@ -30,14 +30,14 @@
       } );
   </script>
 
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-31803258-2', 'auto');
-      ga('send', 'pageview');
-  </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/malden/tutorials/tour_guide.html
+++ b/malden/tutorials/tour_guide.html
@@ -31,17 +31,14 @@
           //$( "button, input, a" ).click( );
       } );
   </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-31803258-2', 'auto');
-      ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/malden/tutorials/two_button_game.html
+++ b/malden/tutorials/two_button_game.html
@@ -32,16 +32,14 @@
       } );
   </script>
 
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-      ga('create', 'UA-31803258-2', 'auto');
-      ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/ball_bounce.html
+++ b/yr/tutorials/ball_bounce.html
@@ -32,16 +32,14 @@
         } );
   </script>
 
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/digital_doodle.html
+++ b/yr/tutorials/digital_doodle.html
@@ -32,16 +32,14 @@
         } );
   </script>
 
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/diybookclub.html
+++ b/yr/tutorials/diybookclub.html
@@ -25,21 +25,14 @@
     } );
   </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-
-
-
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/dontGetFaked.html
+++ b/yr/tutorials/dontGetFaked.html
@@ -24,17 +24,14 @@
   } );
 </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/healthy_plant.html
+++ b/yr/tutorials/healthy_plant.html
@@ -23,16 +23,14 @@
     //$( "button, input, a" ).click( );
   } );
 </script>
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/hello_bonjour.html
+++ b/yr/tutorials/hello_bonjour.html
@@ -22,17 +22,14 @@
     } );
   </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/hour_of_code.html
+++ b/yr/tutorials/hour_of_code.html
@@ -33,16 +33,14 @@
   </script>
 
 
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/mapTheMovement.html
+++ b/yr/tutorials/mapTheMovement.html
@@ -25,21 +25,14 @@
     } );
   </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-
-
-
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/moodCounter.html
+++ b/yr/tutorials/moodCounter.html
@@ -24,17 +24,14 @@
   } );
 </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/mytodolist.html
+++ b/yr/tutorials/mytodolist.html
@@ -26,21 +26,14 @@
   </script>
 
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-
-
-
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/opinion_poll_app.html
+++ b/yr/tutorials/opinion_poll_app.html
@@ -34,21 +34,14 @@
     <a onclick="enlargeVideo('aEoFmKkvdZo')" href="javascript:void(0);"><img width="100%"  src="../images/ball_bounce/ball_bounce_1_ss.png" alt="Ball Bounce tutorial introduction"></a>
   -->
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-
-
-
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/rock-paper-scissors-withAI.html
+++ b/yr/tutorials/rock-paper-scissors-withAI.html
@@ -34,21 +34,14 @@
     <a onclick="enlargeVideo('aEoFmKkvdZo')" href="javascript:void(0);"><img width="100%"  src="../images/ball_bounce/ball_bounce_1_ss.png" alt="Ball Bounce tutorial introduction"></a>
   -->
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-
-
-
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/snapRemix.html
+++ b/yr/tutorials/snapRemix.html
@@ -32,16 +32,14 @@
   } );
 </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/soundlibrary.html
+++ b/yr/tutorials/soundlibrary.html
@@ -34,21 +34,14 @@
     <a onclick="enlargeVideo('aEoFmKkvdZo')" href="javascript:void(0);"><img width="100%"  src="../images/ball_bounce/ball_bounce_1_ss.png" alt="Ball Bounce tutorial introduction"></a>
   -->
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-
-
-
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/talk_to_me.html
+++ b/yr/tutorials/talk_to_me.html
@@ -32,16 +32,14 @@
         } );
   </script>
 
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/therapistBOT.html
+++ b/yr/tutorials/therapistBOT.html
@@ -34,21 +34,14 @@
     <a onclick="enlargeVideo('aEoFmKkvdZo')" href="javascript:void(0);"><img width="100%"  src="../images/ball_bounce/ball_bounce_1_ss.png" alt="Ball Bounce tutorial introduction"></a>
   -->
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  ga('create', 'UA-31803258-2', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-
-
-
-
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 

--- a/yr/tutorials/woof_purr.html
+++ b/yr/tutorials/woof_purr.html
@@ -32,16 +32,14 @@
       } );
   </script>
 
-  <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V6FYGPJVJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-      ga('create', 'UA-31803258-2', 'auto');
-      ga('send', 'pageview');
-
-  </script>
+      gtag('config', 'G-V6FYGPJVJ4');
+    </script>
 </head>
 <body>
 


### PR DESCRIPTION
Google Universal Analytics has been shut down since July. This PR migrates our existing tutorials to using Google Analytics 4. In a future update, I'd like to migrate all of our existing tutorials to using the tutorial markdown template as using that would have saved a lot of time updating these files.

Change-Id: Ia5f970810e5db39ef270079ce7bf62c363dce6fc